### PR TITLE
Added Cron Job for render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@clerk/backend": "^2.2.0",
         "@neondatabase/serverless": "^1.0.1",
         "cors": "^2.8.5",
+        "cron": "^4.3.1",
         "dotenv": "^16.5.0",
         "drizzle-orm": "^0.44.2",
         "express": "^5.1.0"
@@ -960,6 +961,12 @@
         "node": ">=19.0.0"
       }
     },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.15.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.33.tgz",
@@ -1198,6 +1205,19 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cron": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.3.1.tgz",
+      "integrity": "sha512-7x7DoEOxV11t3OPWWMjj1xrL1PGkTV5RV+/54IJTZD7gStiaMploY43EkeBSkDZTLRbUwk+OISbQ0TR133oXyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.6.0",
+        "luxon": "~3.6.0"
+      },
+      "engines": {
+        "node": ">=18.x"
       }
     },
     "node_modules/csstype": {
@@ -1897,6 +1917,15 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/map-obj": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@clerk/backend": "^2.2.0",
     "@neondatabase/serverless": "^1.0.1",
     "cors": "^2.8.5",
+    "cron": "^4.3.1",
     "dotenv": "^16.5.0",
     "drizzle-orm": "^0.44.2",
     "express": "^5.1.0"

--- a/src/config/cron.js
+++ b/src/config/cron.js
@@ -1,0 +1,17 @@
+import cron from "cron";
+import https from "https";
+
+
+const cronJob = new cron.CronJob("*/14 * * * *", () => {
+    https
+       .get(`${process.env.API_URL}/api/health`, (res) => {
+         if (res.statusCode !== 200) {
+           console.error(`Cron job failed with status code: ${res.statusCode}`);
+         }
+         res.on("data", (chunk) => {
+           console.log(`Cron job response: ${chunk}`);
+         });
+       })
+});
+
+export default cronJob;

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,19 @@ import express from "express";
 import cors from "cors";
 import { router as starredRouter } from "./starred.routes.js";
 import welcomeRouter from "./welcome.route.js";
+import cronJob from './config/cron.js';
+
+if (process.env.NODE_ENV == 'production') {
+  cronJob.start();
+}
 
 const app = express();
 app.use(cors());
 app.use(express.json());
+
+app.get("/api/health", (req, res) => {
+  res.status(200).json({ status: "ok" });
+});
 
 app.use("/api/starred", starredRouter);
 


### PR DESCRIPTION
This pull request introduces a new cron job to periodically check the health of the API and adds related functionality to the project. The most important changes include adding the `cron` package, implementing the cron job logic, and integrating it into the application startup process.

### Cron job functionality:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R18): Added the `cron` package as a dependency to enable scheduling functionality.
* [`src/config/cron.js`](diffhunk://#diff-dd7493de7055c060a36641292860eb85813bc35d701e83971f9f2e47c77bce53R1-R17): Implemented a cron job using the `cron` package to send a GET request to the `/api/health` endpoint every 14 minutes. Logs the response or errors if the status code is not 200.

### Application integration:

* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R6-R19): Imported the cron job and started it conditionally in production mode. Added a new `/api/health` endpoint to respond with a status of "ok."

Closes #2 